### PR TITLE
Fix bonus light window times

### DIFF
--- a/ZodiacBuddy/ConfigWindow.cs
+++ b/ZodiacBuddy/ConfigWindow.cs
@@ -231,5 +231,19 @@ internal class ConfigWindow : Window {
             DebugTools.CheckBonusLightDutyTerritories();
         if (ImGui.Button("Check Brave books territory"))
             DebugTools.CheckBraveDutyTerritory();
+        
+        var bonusLightWindow = Util.CurrentBonusLightWindow();
+        if (bonusLightWindow.HasValue) {
+            var (startWindow, endWindow) = bonusLightWindow.Value;
+            
+            var startWindowServerTime = startWindow.ToString(@"HH\:mm");
+            var endWindowServerTime = endWindow.ToString(@"HH\:mm");
+            var startWindowLocal = startWindow.ToLocalTime().ToString(@"HH\:mm");
+            var endWindowLocal = endWindow.ToLocalTime().ToString(@"HH\:mm");
+        
+            ImGui.Text($"Current bonus light window: {startWindowLocal} - {endWindowLocal} ({startWindowServerTime} - {endWindowServerTime} Server Time)");
+        } else {
+            ImGui.Text($"No bonus light window found, check logs");
+        }
     }
 }

--- a/ZodiacBuddy/InformationWindow/InformationWindow.cs
+++ b/ZodiacBuddy/InformationWindow/InformationWindow.cs
@@ -108,14 +108,21 @@ public abstract class InformationWindow {
             ImGui.TextColored(ImGuiColors.DalamudYellow, FontAwesomeIcon.Lightbulb.ToIconString());
             ImGui.PopFont();
 
-            var timeOfDay = DateTime.Now.TimeOfDay;
-            var startEvenHour = timeOfDay.Hours % 2 == 0
-                ? TimeSpan.FromHours(timeOfDay.Hours)
-                : TimeSpan.FromHours(timeOfDay.Hours - 1);
-            var startWindowDate = startEvenHour.ToString(@"hh\:mm");
-            var endWindowDate = startEvenHour.Add(TimeSpan.FromHours(2)).ToString(@"hh\:mm");
-            ImGui.SameLine();
-            ImGui.Text($"{startWindowDate} - {endWindowDate}");
+            var bonusLightWindow = Util.CurrentBonusLightWindow();
+            if (bonusLightWindow.HasValue) {
+                var (startWindow, endWindow) = bonusLightWindow.Value;
+            
+                var startWindowServerTime = startWindow.ToUniversalTime().ToString(@"HH\:mm");
+                var endWindowServerTime = endWindow.ToUniversalTime().ToString(@"HH\:mm");
+                var startWindowLocal = startWindow.ToLocalTime().ToString(@"HH\:mm");
+                var endWindowLocal = endWindow.ToLocalTime().ToString(@"HH\:mm");
+        
+                ImGui.SameLine();
+                ImGui.Text($"Current bonus light window: {startWindowLocal} - {endWindowLocal} ({startWindowServerTime} - {endWindowServerTime} Server Time)");
+            } else {
+                ImGui.SameLine();
+                ImGui.Text($"Bonus light window could not be found, this is a bug.");
+            }
 
             foreach (var territoryId in BonusConfiguration.ActiveBonus) {
                 var dutyName = BonusLightDuty.GetValue(territoryId).DutyName

--- a/ZodiacBuddy/Util.cs
+++ b/ZodiacBuddy/Util.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Collections.Generic;
 using FFXIVClientStructs.FFXIV.Client.Game;
 
 namespace ZodiacBuddy;
@@ -27,5 +27,36 @@ internal static class Util {
             throw new Exception($"InventorySlot{index} was null");
 
         return *slot;
+    }
+
+    private static readonly List<(TimeOnly, int, TimeOnly)> BonusLightWindows = [
+        (new TimeOnly(0, 0), 0, new TimeOnly(2, 0)),
+        (new TimeOnly(2, 0), 0, new TimeOnly(4, 0)),
+        (new TimeOnly(4, 0), 0, new TimeOnly(6, 0)),
+        (new TimeOnly(6, 0), 0, new TimeOnly(8, 0)),
+        (new TimeOnly(8, 0), 0, new TimeOnly(10, 0)),
+        (new TimeOnly(10, 0), 0, new TimeOnly(12, 0)),
+        (new TimeOnly(12, 0), 0, new TimeOnly(14, 0)),
+        (new TimeOnly(14, 0), 0, new TimeOnly(16, 0)),
+        (new TimeOnly(16, 0), 0, new TimeOnly(18, 0)),
+        (new TimeOnly(18, 0), 0, new TimeOnly(20, 0)),
+        (new TimeOnly(20, 0), 0, new TimeOnly(22, 0)),
+        (new TimeOnly(22, 0), 1, new TimeOnly(0, 0)),
+    ];
+    
+    public static (DateTime, DateTime)? CurrentBonusLightWindow() {
+        var now = DateTime.UtcNow;
+        
+        foreach (var (start, addDays, end) in BonusLightWindows) {
+            var startWindow = new DateTime(DateOnly.FromDateTime(now), start, DateTimeKind.Utc);
+            var endWindow = new DateTime(DateOnly.FromDateTime(now).AddDays(addDays), end, DateTimeKind.Utc);
+
+            if (now >= startWindow && now < endWindow) {
+                return (startWindow, endWindow);
+            }
+        }
+
+        Service.PluginLog.Error($"No bonus light window found for UTC time: {now:O}");
+        return null;
     }
 }


### PR DESCRIPTION
The current implementation shows a 2 hour long window starting at the most recent even-numbered hour in the user's local time, but this is incorrect since the bonus light windows are anchored to server time (UTC), so it will show the wrong value unless you are an even number of whole hours away from UTC.

Additionally, I suspect that the windows are not always two hours long, but instead the window rotates at 00:00 UTC, 02:00 UTC, 04:00 UTC, …, 22:00 UTC. This is almost the same thing, but it would show the wrong value for the 22:00 UTC - 00:00 UTC bonus window when there is a leap second, where this would say that the window is 22:00 - 23:59 instead of 22:00 - 00:00. Does this matter? Probably not, but since I was revisiting this I wanted to do it as correctly as I could.

This new code uses window start times instead of durations and calculates everything in UTC before converting it to the user's local time.